### PR TITLE
Fix bug with connection to memcache:

### DIFF
--- a/capella/src/cache/Cache.php
+++ b/capella/src/cache/Cache.php
@@ -161,8 +161,8 @@ class Cache
     private function getConfig()
     {
         $config = [
-            'host' => Env::get('CACHE_HOST') || 'localhost',
-            'port' => Env::get('CACHE_PORT') || 11211
+            'host' => Env::get('CACHE_HOST') ?: 'localhost',
+            'port' => Env::get('CACHE_PORT') ?: 11211
         ];
 
         return $config;


### PR DESCRIPTION
 MemcachePool::get(): Server 1 (tcp 1, udp 0) failed with: Invalid argument (22)
